### PR TITLE
New methods to set the compression algorithm of entries

### DIFF
--- a/REFLECTION
+++ b/REFLECTION
@@ -429,7 +429,7 @@ Extension [ <persistent> extension #16 zip version 1.12.5-dev ] {
           }
         }
 
-        Method [ <internal:zip> public method setCompressionMethodName ] {
+        Method [ <internal:zip> public method setCompressionName ] {
 
           - Parameters [3] {
             Parameter #0 [ <required> $name ]
@@ -438,7 +438,7 @@ Extension [ <persistent> extension #16 zip version 1.12.5-dev ] {
           }
         }
 
-        Method [ <internal:zip> public method setCompressionMethodIndex ] {
+        Method [ <internal:zip> public method setCompressionIndex ] {
 
           - Parameters [3] {
             Parameter #0 [ <required> $index ]

--- a/REFLECTION
+++ b/REFLECTION
@@ -151,7 +151,7 @@ Extension [ <persistent> extension #16 zip version 1.12.5-dev ] {
       - Properties [0] {
       }
 
-      - Methods [35] {
+      - Methods [37] {
         Method [ <internal:zip> public method open ] {
 
           - Parameters [2] {
@@ -426,6 +426,24 @@ Extension [ <persistent> extension #16 zip version 1.12.5-dev ] {
             Parameter #1 [ <required> &$opsys ]
             Parameter #2 [ <required> &$attr ]
             Parameter #3 [ <optional> $flags ]
+          }
+        }
+
+        Method [ <internal:zip> public method setCompressionMethodName ] {
+
+          - Parameters [3] {
+            Parameter #0 [ <required> $name ]
+            Parameter #1 [ <required> $method ]
+            Parameter #2 [ <optional> $compflags ]
+          }
+        }
+
+        Method [ <internal:zip> public method setCompressionMethodIndex ] {
+
+          - Parameters [3] {
+            Parameter #0 [ <required> $index ]
+            Parameter #1 [ <required> $method ]
+            Parameter #2 [ <optional> $compflags ]
           }
         }
       }

--- a/examples/set_compression.php
+++ b/examples/set_compression.php
@@ -1,0 +1,21 @@
+<?php
+error_reporting(E_ALL);
+if (!extension_loaded('zip')) {
+    dl('zip.so');
+}
+
+$zip = new ZipArchive();
+$filename = "a.zip";
+
+if (!$zip->open($filename, ZIPARCHIVE::CREATE | ZipArchive::OVERWRITE)) {
+	exit("cannot open <$filename>\n");
+}
+
+$zip->addFromString("testfilephp.txt", "#1 This is a test string added as testfilephp.txt.\n");
+$zip->addFromString("testfilephp2.txt", "#2 This is a test string added as testfilephp2.txt.\n");
+$zip->addFile("too.php", "testfromfile.php");
+
+$zip->setCompressionName("testfilephp2.txt", ZipArchive::CM_STORE);
+$zip->setCompressionIndex(2, ZipArchive::CM_STORE);
+
+$zip->close();

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,8 @@
   <license>PHP 3.01</license>
   <notes>
 - add OPSYS_Z_CPM missing constant
+- new methods for ZipArchive:
+  setCompressionMethodName, setCompressionMethodIndex
   </notes>
   <contents>
     <dir name="/">

--- a/package.xml
+++ b/package.xml
@@ -30,7 +30,7 @@
   <notes>
 - add OPSYS_Z_CPM missing constant
 - new methods for ZipArchive:
-  setCompressionMethodName, setCompressionMethodIndex
+  setCompressionName, setCompressionIndex
   </notes>
   <contents>
     <dir name="/">

--- a/package.xml
+++ b/package.xml
@@ -171,6 +171,7 @@
         <file name="oo_properties.phpt" role="test"/>
         <file name="oo_rename.phpt" role="test"/>
         <file name="oo_setcomment.phpt" role="test"/>
+        <file name="oo_setcompression.phpt" role="test"/>
         <file name="oo_stream.phpt" role="test"/>
         <file name="pecl12414.phpt" role="test"/>
         <file name="pecl12414.zip" role="test"/>

--- a/package.xml
+++ b/package.xml
@@ -218,6 +218,7 @@
         <file name="get_set_comments.php" role="doc"/>
         <file name="addglob.php" role="doc"/>
         <file name="addpattern.php" role="doc"/>
+        <file name="set_compression.php" role="doc"/>
       </dir> <!-- examples -->
     </dir>
   </contents>

--- a/php_zip.c
+++ b/php_zip.c
@@ -2387,9 +2387,9 @@ static ZIPARCHIVE_METHOD(getCommentIndex)
 }
 /* }}} */
 
-/* {{{ proto bool ZipArchive::setCompressionMethodName(string name, int comp_method[, int comp_flags])
-Set the compression method of an entry using its Name */
-static ZIPARCHIVE_METHOD(setCompressionMethodName)
+/* {{{ proto bool ZipArchive::setCompressionName(string name, int comp_method[, int comp_flags])
+Set the compression of a file in zip, using its name */
+static ZIPARCHIVE_METHOD(setCompressionName)
 {
 	struct zip *intern;
 	zval *this = getThis();
@@ -2426,9 +2426,9 @@ static ZIPARCHIVE_METHOD(setCompressionMethodName)
 }
 /* }}} */
 
-/* {{{ proto bool ZipArchive::setCompressionMethodIndex(int index, int comp_method[, int comp_flags])
-Set the compression method of an entry using its index */
-static ZIPARCHIVE_METHOD(setCompressionMethodIndex)
+/* {{{ proto bool ZipArchive::setCompressionIndex(int index, int comp_method[, int comp_flags])
+Set the compression of a file in zip, using its index */
+static ZIPARCHIVE_METHOD(setCompressionIndex)
 {
 	struct zip *intern;
 	zval *this = getThis();
@@ -3048,13 +3048,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ziparchive_getextattrindex, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif /* ifdef ZIP_OPSYS_DEFAULT */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ziparchive_setcompmethodname, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ziparchive_setcompname, 0, 0, 2)
 	ZEND_ARG_INFO(0, name)
 	ZEND_ARG_INFO(0, method)
 	ZEND_ARG_INFO(0, compflags)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ziparchive_setcompmethodindex, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ziparchive_setcompindex, 0, 0, 2)
 	ZEND_ARG_INFO(0, index)
 	ZEND_ARG_INFO(0, method)
 	ZEND_ARG_INFO(0, compflags)
@@ -3098,8 +3098,8 @@ static const zend_function_entry zip_class_functions[] = {
 	ZIPARCHIVE_ME(setExternalAttributesIndex,	arginfo_ziparchive_setextattrindex, ZEND_ACC_PUBLIC)
 	ZIPARCHIVE_ME(getExternalAttributesName,	arginfo_ziparchive_getextattrname, ZEND_ACC_PUBLIC)
 	ZIPARCHIVE_ME(getExternalAttributesIndex,	arginfo_ziparchive_getextattrindex, ZEND_ACC_PUBLIC)
-	ZIPARCHIVE_ME(setCompressionMethodName,		arginfo_ziparchive_setcompmethodname, ZEND_ACC_PUBLIC)
-	ZIPARCHIVE_ME(setCompressionMethodIndex,	arginfo_ziparchive_setcompmethodindex, ZEND_ACC_PUBLIC)
+	ZIPARCHIVE_ME(setCompressionName,	arginfo_ziparchive_setcompname, ZEND_ACC_PUBLIC)
+	ZIPARCHIVE_ME(setCompressionIndex,	arginfo_ziparchive_setcompindex, ZEND_ACC_PUBLIC)
 	{NULL, NULL, NULL}
 };
 /* }}} */

--- a/php_zip.c
+++ b/php_zip.c
@@ -98,10 +98,10 @@ static int le_zip_entry;
 #define PHP_ZIP_SET_FILE_COMMENT(za, index, comment, comment_len) \
 	if (comment_len == 0) { \
 		/* Passing NULL remove the existing comment */ \
-		if (zip_set_file_comment(intern, index, NULL, 0) < 0) { \
+		if (zip_set_file_comment(za, index, NULL, 0) < 0) { \
 			RETURN_FALSE; \
 		} \
-	} else if (zip_set_file_comment(intern, index, comment, comment_len) < 0) { \
+	} else if (zip_set_file_comment(za, index, comment, comment_len) < 0) { \
 		RETURN_FALSE; \
 	} \
 	RETURN_TRUE;
@@ -2387,6 +2387,73 @@ static ZIPARCHIVE_METHOD(getCommentIndex)
 }
 /* }}} */
 
+/* {{{ proto bool ZipArchive::setCompressionMethodName(string name, int comp_method[, int comp_flags])
+Set the compression method of an entry using its Name */
+static ZIPARCHIVE_METHOD(setCompressionMethodName)
+{
+	struct zip *intern;
+	zval *this = getThis();
+	int name_len;
+	char *name;
+	zip_int64_t idx;
+	long comp_method, comp_flags = 0;
+
+	if (!this) {
+		RETURN_FALSE;
+	}
+
+	ZIP_FROM_OBJECT(intern, this);
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl|l",
+			&name, &name_len, &comp_method, &comp_flags) == FAILURE) {
+		return;
+	}
+
+	if (name_len < 1) {
+		php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Empty string as entry name");
+	}
+
+	idx = zip_name_locate(intern, name, 0);
+	if (idx < 0) {
+		RETURN_FALSE;
+	}
+
+	if (zip_set_file_compression(intern, (zip_uint64_t)idx,
+			(zip_int32_t)comp_method, (zip_uint32_t)comp_flags) != 0) {
+		RETURN_FALSE;
+	}
+	RETURN_TRUE;
+}
+/* }}} */
+
+/* {{{ proto bool ZipArchive::setCompressionMethodIndex(int index, int comp_method[, int comp_flags])
+Set the compression method of an entry using its index */
+static ZIPARCHIVE_METHOD(setCompressionMethodIndex)
+{
+	struct zip *intern;
+	zval *this = getThis();
+	long index;
+	long comp_method, comp_flags = 0;
+
+	if (!this) {
+		RETURN_FALSE;
+	}
+
+	ZIP_FROM_OBJECT(intern, this);
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|l",
+			&index, &comp_method, &comp_flags) == FAILURE) {
+		return;
+	}
+
+	if (zip_set_file_compression(intern, (zip_uint64_t)index,
+			(zip_int32_t)comp_method, (zip_uint32_t)comp_flags) != 0) {
+		RETURN_FALSE;
+	}
+	RETURN_TRUE;
+}
+/* }}} */
+
 /* {{{ proto bool ZipArchive::deleteIndex(int index)
 Delete a file using its index */
 static ZIPARCHIVE_METHOD(deleteIndex)
@@ -2980,6 +3047,18 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ziparchive_getextattrindex, 0, 0, 3)
 	ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 #endif /* ifdef ZIP_OPSYS_DEFAULT */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ziparchive_setcompmethodname, 0, 0, 2)
+	ZEND_ARG_INFO(0, name)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, compflags)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ziparchive_setcompmethodindex, 0, 0, 2)
+	ZEND_ARG_INFO(0, index)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, compflags)
+ZEND_END_ARG_INFO()
 /* }}} */
 
 /* {{{ ze_zip_object_class_functions */
@@ -3019,6 +3098,8 @@ static const zend_function_entry zip_class_functions[] = {
 	ZIPARCHIVE_ME(setExternalAttributesIndex,	arginfo_ziparchive_setextattrindex, ZEND_ACC_PUBLIC)
 	ZIPARCHIVE_ME(getExternalAttributesName,	arginfo_ziparchive_getextattrname, ZEND_ACC_PUBLIC)
 	ZIPARCHIVE_ME(getExternalAttributesIndex,	arginfo_ziparchive_getextattrindex, ZEND_ACC_PUBLIC)
+	ZIPARCHIVE_ME(setCompressionMethodName,		arginfo_ziparchive_setcompmethodname, ZEND_ACC_PUBLIC)
+	ZIPARCHIVE_ME(setCompressionMethodIndex,	arginfo_ziparchive_setcompmethodindex, ZEND_ACC_PUBLIC)
 	{NULL, NULL, NULL}
 };
 /* }}} */

--- a/tests/oo_setcompression.phpt
+++ b/tests/oo_setcompression.phpt
@@ -1,0 +1,72 @@
+--TEST--
+setCompressionName and setCompressionIndex methods
+--SKIPIF--
+<?php
+/* $Id$ */
+if (!extension_loaded('zip')) die('skip');
+?>
+--FILE--
+<?php
+$tmpfile = dirname(__FILE__) . '/__tmp_oo_set_compression.zip';
+
+if (file_exists($tmpfile)) {
+	unlink($tmpfile);
+}
+
+// generate the ZIP file
+$zip = new ZipArchive;
+if ($zip->open($tmpfile, ZipArchive::CREATE) !== TRUE) {
+	exit('failed');
+}
+
+$zip->addFromString('entry1.txt', 'entry #1');
+$zip->addFromString('entry2.txt', 'entry #2');
+$zip->addFromString('dir/entry3.txt', 'entry #3');
+$zip->addFromString('entry4.txt', 'entry #4');
+$zip->addFromString('entry5.txt', 'entry #5');
+$zip->addFromString('entry6.txt', 'entry #6');
+$zip->addFromString('entry7.txt', 'entry #7');
+
+var_dump($zip->setCompressionName('entry2.txt', ZipArchive::CM_DEFAULT));
+var_dump($zip->setCompressionName('dir/entry3.txt', ZipArchive::CM_STORE));
+var_dump($zip->setCompressionName('entry4.txt', ZipArchive::CM_DEFLATE));
+
+var_dump($zip->setCompressionIndex(4, ZipArchive::CM_STORE));
+var_dump($zip->setCompressionIndex(5, ZipArchive::CM_DEFLATE));
+var_dump($zip->setCompressionIndex(6, ZipArchive::CM_DEFAULT));
+
+if (!$zip->close()) {
+	exit('failed');
+}
+
+
+// check the ZIP file
+$zip = zip_open($tmpfile);
+if (!is_resource($zip)) {
+	exit('failed');
+}
+
+while ($e = zip_read($zip)) {
+	echo zip_entry_name($e) . ': ' . zip_entry_compressionmethod($e) . "\n";
+}
+zip_close($zip);
+?>
+--CLEAN--
+<?php
+$tmpfile = dirname(__FILE__) . '/__tmp_oo_set_compression.zip';
+unlink($tmpfile);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+entry1.txt: deflated
+entry2.txt: deflated
+dir/entry3.txt: stored
+entry4.txt: deflated
+entry5.txt: stored
+entry6.txt: deflated
+entry7.txt: deflated


### PR DESCRIPTION
Two methods were added to the class ZipArchive to set the compression algorithm of entries, identified either by name or index. They simply call function zip_set_file_compression() of libzip (so the same limitations exist about available algorithms and compression flags).