### PR TITLE
Sync libzip-1.0.1 upgrade with the Windows side

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -24,11 +24,14 @@ if (PHP_ZIP != "no") {
 			zip_set_archive_comment.c zip_set_archive_flag.c zip_set_default_password.c zip_set_file_comment.c\
 			zip_set_file_compression.c zip_set_name.c zip_source_buffer.c zip_source_close.c zip_source_crc.c\
 			zip_source_deflate.c zip_source_error.c zip_source_file.c zip_source_filep.c zip_source_free.c\
-			zip_source_function.c zip_source_layered.c zip_source_open.c zip_source_pkware.c zip_source_pop.c\
+			zip_source_function.c zip_source_layered.c zip_source_open.c zip_source_pkware.c \
 			zip_source_read.c zip_source_stat.c zip_source_window.c zip_source_zip.c zip_source_zip_new.c\
 			zip_stat.c zip_stat_index.c zip_stat_init.c zip_strerror.c zip_string.c zip_unchange.c zip_unchange_all.c\
 			zip_unchange_archive.c zip_unchange_data.c zip_utf-8.c mkstemp.c \
-			zip_file_set_external_attributes.c zip_file_get_external_attributes.c", "zip");
+			zip_file_set_external_attributes.c zip_file_get_external_attributes.c zip_source_write.c \
+			zip_source_call.c zip_source_supports.c zip_buffer.c zip_source_seek.c zip_source_tell.c \
+			zip_io_util.c zip_source_remove.c zip_source_rollback_write.c zip_source_commit_write.c \
+			zip_source_tell_write.c zip_source_begin_write.c zip_source_seek_write.c", "zip");
 
 		AC_DEFINE('HAVE_ZIP', 1);
 		ADD_FLAG("CFLAGS_ZIP", "/D _WIN32");

--- a/lib/php_zip_config.w32.h
+++ b/lib/php_zip_config.w32.h
@@ -54,7 +54,12 @@ typedef long long ssize_t;
 #  endif
 #endif
 
-# undef strcasecmp
-# define strcasecmp _strcmpi
+#if !defined(EOPNOTSUPP) && defined(_WIN32)
+# define EOPNOTSUPP 130
+#endif
+
+#if !defined(EOVERFLOW) && defined(_WIN32)
+# define EOVERFLOW 132
+#endif
 
 #endif /* HAD_CONFIG_H */

--- a/lib/php_zip_config.w32.h
+++ b/lib/php_zip_config.w32.h
@@ -54,6 +54,9 @@ typedef long long ssize_t;
 #  endif
 #endif
 
+# undef strcasecmp
+# define strcasecmp _strcmpi
+
 #if !defined(EOPNOTSUPP) && defined(_WIN32)
 # define EOPNOTSUPP 130
 #endif

--- a/lib/zip.h
+++ b/lib/zip.h
@@ -37,7 +37,7 @@
 
 #ifndef ZIP_EXTERN
 # ifndef ZIP_STATIC
-#  ifdef _WIN32
+#  if defined(_WIN32) && defined(PHP_ZIP_EXPORTS)
 #   define ZIP_EXTERN __declspec(dllimport)
 #  elif defined(__GNUC__) && __GNUC__ >= 4
 #   define ZIP_EXTERN __attribute__ ((visibility ("default")))

--- a/lib/zip_dirent.c
+++ b/lib/zip_dirent.c
@@ -618,6 +618,7 @@ _zip_dirent_write(zip_t *za, zip_dirent_t *de, zip_flags_t flags)
     bool is_really_zip64;
     zip_uint8_t buf[CDENTRYSIZE];
     zip_buffer_t *buffer;
+    zip_uint32_t ef_total_size;
 
     ef = NULL;
 
@@ -654,6 +655,7 @@ _zip_dirent_write(zip_t *za, zip_dirent_t *de, zip_flags_t flags)
     if (is_zip64) {
         zip_uint8_t ef_zip64[EFZIP64SIZE];
         zip_buffer_t *ef_buffer = _zip_buffer_new(ef_zip64, sizeof(ef_zip64));
+        zip_extra_field_t *ef64;
         if (ef_buffer == NULL) {
             zip_error_set(&za->error, ZIP_ER_MEMORY, 0);
 	    _zip_ef_free(ef);
@@ -687,7 +689,7 @@ _zip_dirent_write(zip_t *za, zip_dirent_t *de, zip_flags_t flags)
             return -1;
         }
 
-        zip_extra_field_t *ef64 = _zip_ef_new(ZIP_EF_ZIP64, (zip_uint16_t)(_zip_buffer_offset(ef_buffer)), ef_zip64, ZIP_EF_BOTH);
+        ef64 = _zip_ef_new(ZIP_EF_ZIP64, (zip_uint16_t)(_zip_buffer_offset(ef_buffer)), ef_zip64, ZIP_EF_BOTH);
         _zip_buffer_free(ef_buffer);
         ef64->next = ef;
         ef = ef64;
@@ -740,7 +742,7 @@ _zip_dirent_write(zip_t *za, zip_dirent_t *de, zip_flags_t flags)
 
     _zip_buffer_put_16(buffer, _zip_string_length(de->filename));
     /* TODO: check for overflow */
-    zip_uint32_t ef_total_size = (zip_uint32_t)_zip_ef_size(de->extra_fields, flags) + (zip_uint32_t)_zip_ef_size(ef, ZIP_EF_BOTH);
+    ef_total_size = (zip_uint32_t)_zip_ef_size(de->extra_fields, flags) + (zip_uint32_t)_zip_ef_size(ef, ZIP_EF_BOTH);
     _zip_buffer_put_16(buffer, (zip_uint16_t)ef_total_size);
     
     if ((flags & ZIP_FL_LOCAL) == 0) {

--- a/lib/zip_source_buffer.c
+++ b/lib/zip_source_buffer.c
@@ -388,12 +388,13 @@ buffer_write(buffer_t *buffer, const zip_uint8_t *data, zip_uint64_t length, zip
 	
 	if (needed_fragments > buffer->fragments_capacity) {
 	    zip_uint64_t new_capacity = buffer->fragments_capacity;
+	    zip_uint8_t **fragments;
 
 	    while (new_capacity < needed_fragments) {
 		new_capacity *= 2;
 	    }
 
-	    zip_uint8_t **fragments = realloc(buffer->fragments, new_capacity * sizeof(*fragments));
+	    fragments = realloc(buffer->fragments, new_capacity * sizeof(*fragments));
 
 	    if (fragments == NULL) {
 		zip_error_set(error, ZIP_ER_MEMORY, 0);

--- a/lib/zip_source_filep.c
+++ b/lib/zip_source_filep.c
@@ -183,7 +183,13 @@ create_temp_output(struct read_file *ctx)
     }
     sprintf(temp, "%s.XXXXXX", ctx->fname);
 
+#ifdef _WIN32
+    /* This might work under VS2015, however there's no good documentation
+    	about it. So let it be for now. */
+    mask = 0;
+#else
     mask = umask(S_IXUSR | S_IRWXG | S_IRWXO);
+#endif
     if ((tfd=mkstemp(temp)) == -1) {
         zip_error_set(&ctx->error, ZIP_ER_TMPOPEN, errno);
 	umask(mask);

--- a/lib/zipint.h
+++ b/lib/zipint.h
@@ -34,8 +34,12 @@
   IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
+#ifdef PHP_WIN32
+# include "php_zip_config.w32.h"
+#else
+# ifdef HAVE_CONFIG_H
+#  include "config.h"
+# endif
 #endif
 
 /* to have *_MAX definitions for all types when compiling with g++ */

--- a/lib/zipint.h
+++ b/lib/zipint.h
@@ -47,10 +47,10 @@
 
 #include <zlib.h>
 
-#ifdef _WIN32
-#define ZIP_EXTERN __declspec(dllexport)
+#ifdef PHP_WIN32
 /* for dup(), close(), etc. */
 #include <io.h>
+#include "config.w32.h"
 #endif
 
 #ifndef _ZIP_COMPILING_DEPRECATED

--- a/libzip.patch
+++ b/libzip.patch
@@ -1,38 +1,106 @@
 diff -u lib.orig/zip.h lib/zip.h
---- lib.orig/zip.h	Sun Sep 22 11:35:53 2013
-+++ lib/zip.h	Mon Dec 23 10:36:14 2013
-@@ -36,15 +36,21 @@
+--- lib.orig/zip.h	Wed Apr 29 17:43:29 2015
++++ lib/zip.h	Tue May  5 15:33:32 2015
+@@ -37,7 +37,7 @@
  
- 
+ #ifndef ZIP_EXTERN
+ # ifndef ZIP_STATIC
+-#  ifdef _WIN32
++#  if defined(_WIN32) && defined(PHP_ZIP_EXPORTS)
+ #   define ZIP_EXTERN __declspec(dllimport)
+ #  elif defined(__GNUC__) && __GNUC__ >= 4
+ #   define ZIP_EXTERN __attribute__ ((visibility ("default")))
+diff -u lib.orig/zip_dirent.c lib/zip_dirent.c
+--- lib.orig/zip_dirent.c	Wed Apr 29 17:43:29 2015
++++ lib/zip_dirent.c	Tue May  5 14:58:15 2015
+@@ -618,6 +618,7 @@
+     bool is_really_zip64;
+     zip_uint8_t buf[CDENTRYSIZE];
+     zip_buffer_t *buffer;
++    zip_uint32_t ef_total_size;
  
--#ifndef ZIP_EXTERN
--#ifdef _WIN32
--#define ZIP_EXTERN __declspec(dllimport)
-+#include "main/php.h"
-+ 
-+#ifdef PHP_WIN32
-+#ifdef PHP_ZIP_EXPORTS
-+#  define ZIP_EXTERN __declspec(dllexport) _stdcall
-+# else
-+#  define ZIP_EXTERN
-+# endif
- #elif defined(__GNUC__) && __GNUC__ >= 4
--#define ZIP_EXTERN __attribute__ ((visibility ("default")))
-+# define ZIP_EXTERN __attribute__ ((visibility("default")))
- #else
--#define ZIP_EXTERN
--#endif
-+# define ZIP_EXTERN
- #endif
-+ 
-+
+     ef = NULL;
  
- #ifdef __cplusplus
- extern "C" {
+@@ -654,6 +655,7 @@
+     if (is_zip64) {
+         zip_uint8_t ef_zip64[EFZIP64SIZE];
+         zip_buffer_t *ef_buffer = _zip_buffer_new(ef_zip64, sizeof(ef_zip64));
++        zip_extra_field_t *ef64;
+         if (ef_buffer == NULL) {
+             zip_error_set(&za->error, ZIP_ER_MEMORY, 0);
+ 	    _zip_ef_free(ef);
+@@ -687,7 +689,7 @@
+             return -1;
+         }
+ 
+-        zip_extra_field_t *ef64 = _zip_ef_new(ZIP_EF_ZIP64, (zip_uint16_t)(_zip_buffer_offset(ef_buffer)), ef_zip64, ZIP_EF_BOTH);
++        ef64 = _zip_ef_new(ZIP_EF_ZIP64, (zip_uint16_t)(_zip_buffer_offset(ef_buffer)), ef_zip64, ZIP_EF_BOTH);
+         _zip_buffer_free(ef_buffer);
+         ef64->next = ef;
+         ef = ef64;
+@@ -740,7 +742,7 @@
+ 
+     _zip_buffer_put_16(buffer, _zip_string_length(de->filename));
+     /* TODO: check for overflow */
+-    zip_uint32_t ef_total_size = (zip_uint32_t)_zip_ef_size(de->extra_fields, flags) + (zip_uint32_t)_zip_ef_size(ef, ZIP_EF_BOTH);
++    ef_total_size = (zip_uint32_t)_zip_ef_size(de->extra_fields, flags) + (zip_uint32_t)_zip_ef_size(ef, ZIP_EF_BOTH);
+     _zip_buffer_put_16(buffer, (zip_uint16_t)ef_total_size);
+     
+     if ((flags & ZIP_FL_LOCAL) == 0) {
+diff -u lib.orig/zip_source_buffer.c lib/zip_source_buffer.c
+--- lib.orig/zip_source_buffer.c	Tue Nov  4 15:47:37 2014
++++ lib/zip_source_buffer.c	Tue May  5 15:09:48 2015
+@@ -388,12 +388,13 @@
+ 	
+ 	if (needed_fragments > buffer->fragments_capacity) {
+ 	    zip_uint64_t new_capacity = buffer->fragments_capacity;
++	    zip_uint8_t **fragments;
+ 
+ 	    while (new_capacity < needed_fragments) {
+ 		new_capacity *= 2;
+ 	    }
+ 
+-	    zip_uint8_t **fragments = realloc(buffer->fragments, new_capacity * sizeof(*fragments));
++	    fragments = realloc(buffer->fragments, new_capacity * sizeof(*fragments));
+ 
+ 	    if (fragments == NULL) {
+ 		zip_error_set(error, ZIP_ER_MEMORY, 0);
+diff -u lib.orig/zip_source_filep.c lib/zip_source_filep.c
+--- lib.orig/zip_source_filep.c	Mon May  4 22:49:13 2015
++++ lib/zip_source_filep.c	Tue May  5 15:22:49 2015
+@@ -183,7 +183,13 @@
+     }
+     sprintf(temp, "%s.XXXXXX", ctx->fname);
+ 
++#ifdef _WIN32
++    /* This might work under VS2015, however there's no good documentation
++    	about it. So let it be for now. */
++    mask = 0;
++#else
+     mask = umask(S_IXUSR | S_IRWXG | S_IRWXO);
++#endif
+     if ((tfd=mkstemp(temp)) == -1) {
+         zip_error_set(&ctx->error, ZIP_ER_TMPOPEN, errno);
+ 	umask(mask);
 diff -u lib.orig/zipint.h lib/zipint.h
---- lib.orig/zipint.h	Thu Nov 28 11:27:17 2013
-+++ lib/zipint.h	Mon Dec 23 10:59:40 2013
-@@ -39,10 +39,10 @@
+--- lib.orig/zipint.h	Wed Apr 29 17:43:29 2015
++++ lib/zipint.h	Tue May  5 15:45:41 2015
+@@ -34,8 +34,12 @@
+   IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#ifdef HAVE_CONFIG_H
+-#include "config.h"
++#ifdef PHP_WIN32
++# include "php_zip_config.w32.h"
++#else
++# ifdef HAVE_CONFIG_H
++#  include "config.h"
++# endif
+ #endif
+ 
+ /* to have *_MAX definitions for all types when compiling with g++ */
+@@ -43,10 +47,10 @@
  
  #include <zlib.h>
  
@@ -45,25 +113,3 @@ diff -u lib.orig/zipint.h lib/zipint.h
  #endif
  
  #ifndef _ZIP_COMPILING_DEPRECATED
-@@ -50,7 +50,11 @@
- #endif
- 
- #include "zip.h"
--#include "config.h"
-+#ifdef PHP_WIN32
-+# include "php_zip_config.w32.h"
-+#else
-+# include "config.h"
-+#endif
- 
- #ifdef HAVE_MOVEFILEEXA
- #include <windows.h>
-@@ -77,7 +81,7 @@
- #if defined(HAVE__OPEN)
- #define open(a, b, c)	_open((a), (b))
- #endif
--#if defined(HAVE__SNPRINTF)
-+#if defined(HAVE__SNPRINTF) && !defined(PHP_WIN32)
- #define snprintf	_snprintf
- #endif
- #if defined(HAVE__STRDUP) && !defined(HAVE_STRDUP)


### PR DESCRIPTION
- applied the previous patch
- made some C89 fixe
- synced the config.w32

PHP 5.4 seems to be fine. Only one test fails yet through everywhere

TEST 34/50 [C:\php-sdk\php56\vc11\x64\php-5.6.8-src\ext\zip\tests\oo_properties.phpt]
========DIFF========
024+
025+ Warning: main(): Cannot destroy the zip context in C:\php-sdk\php56\vc11\x64\php-5.6.8-src\ext\zip\tests\oo_properties.php on line 25

However not sure it's the libzip or the ext itself, so needs more investigation.
