### PR TITLE
Remove unused Git ident attributes from zip extension

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,6 +1,4 @@
-dnl
-dnl $Id$
-dnl
+dnl config.m4 for extension zip
 
 PHP_ARG_ENABLE(zip, for zip archive read/writesupport,
 [  --enable-zip            Include Zip read/write support])

--- a/config.w32
+++ b/config.w32
@@ -1,4 +1,3 @@
-// $Id$
 // vim:ft=javascript
 
 ARG_ENABLE("zip", "ZIP support", "yes");

--- a/examples/im.php
+++ b/examples/im.php
@@ -1,5 +1,5 @@
 <?php
-/* $Id$ */
+
 $im = imagecreatefromgif('zip://' . dirname(__FILE__) . '/test_im.zip#pear_item.gif');
 imagepng($im, 'a.png');
 

--- a/examples/odt.php
+++ b/examples/odt.php
@@ -1,5 +1,5 @@
 <?php
-/* $Id$ */
+
 $reader = new XMLReader();
 
 $reader->open('zip://' . dirname(__FILE__) . '/test.odt#meta.xml');

--- a/tests/bug11216.phpt
+++ b/tests/bug11216.phpt
@@ -2,7 +2,6 @@
 Bug #11216 (::addEmptyDir() crashes when the directory already exists)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
  ?>
 --FILE--

--- a/tests/bug14962.phpt
+++ b/tests/bug14962.phpt
@@ -2,7 +2,6 @@
 Bug #14962 (::extractTo second argument is not really optional)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/bug38943_2.phpt
+++ b/tests/bug38943_2.phpt
@@ -2,7 +2,6 @@
 #38943, properties in extended class cannot be set (5.3)
 --SKIPIF--
 <?php
-/* $Id: bug38943_2.phpt 271800 2008-12-24 11:28:25Z pajoye $ */
 if(!extension_loaded('zip')) die('skip');
 if (version_compare(PHP_VERSION, "5.3", "<")) die('skip test for5.3+ only');
 ?>

--- a/tests/bug47667.phpt
+++ b/tests/bug47667.phpt
@@ -2,7 +2,6 @@
 Bug #47667 (ZipArchive::OVERWRITE seems to have no effect)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/bug49072.phpt
+++ b/tests/bug49072.phpt
@@ -2,7 +2,6 @@
 Bug #49072 (feof never returns true for damaged file in zip)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/bug53579.phpt
+++ b/tests/bug53579.phpt
@@ -2,7 +2,6 @@
 Bug #53579 (stream_get_contents() segfaults on ziparchive streams)
 --SKIPIF--
 <?php
-/* $Id: oo_stream.phpt 260091 2008-05-21 09:27:41Z pajoye $ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/bug64342_1.phpt
+++ b/tests/bug64342_1.phpt
@@ -2,7 +2,6 @@
 Bug #64342 ZipArchive::addFile() has to check file existence (variation 2)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/bug7214.phpt
+++ b/tests/bug7214.phpt
@@ -2,7 +2,6 @@
 Bug #7214 (zip_entry_read() binary safe)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
  ?>
 --FILE--

--- a/tests/bug72258.phpt
+++ b/tests/bug72258.phpt
@@ -2,7 +2,6 @@
 Bug #72258 ZipArchive converts filenames to unrecoverable form
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/bug7658.phpt
+++ b/tests/bug7658.phpt
@@ -2,7 +2,6 @@
 Bug #7658 (modify archive with general bit flag 3 set)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/bug8009.phpt
+++ b/tests/bug8009.phpt
@@ -2,7 +2,6 @@
 Bug #8009 (cannot add again same entry to an archive)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/bug8700.phpt
+++ b/tests/bug8700.phpt
@@ -2,7 +2,6 @@
 Bug #8700 (getFromIndex(0) fails)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_addemptydir.phpt
+++ b/tests/oo_addemptydir.phpt
@@ -2,7 +2,6 @@
 ziparchive::addEmptyDir
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_addfile.phpt
+++ b/tests/oo_addfile.phpt
@@ -2,7 +2,6 @@
 ziparchive::addFile() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_addglob.phpt
+++ b/tests/oo_addglob.phpt
@@ -6,7 +6,6 @@ w/Kenzo over the shoulder
 #phptek Chicago 2014
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_addpattern.phpt
+++ b/tests/oo_addpattern.phpt
@@ -6,7 +6,6 @@ w/Kenzo over the shoulder
 #phptek Chicago 2014
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_close.phpt
+++ b/tests/oo_close.phpt
@@ -2,7 +2,6 @@
 zip::close() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_count.phpt
+++ b/tests/oo_count.phpt
@@ -2,7 +2,6 @@
 ziparchive::count()
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_delete.phpt
+++ b/tests/oo_delete.phpt
@@ -2,7 +2,6 @@
 Delete entries
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_encryption.phpt
+++ b/tests/oo_encryption.phpt
@@ -2,7 +2,6 @@
 ZipArchive::setEncryption*() functions
 --SKIPIF--
 <?php
-/* $Id$ */
 if (!extension_loaded('zip')) die('skip');
 if (!method_exists('ZipArchive', 'setEncryptionName')) die('skip encrytion not supported');
 ?>

--- a/tests/oo_ext_zip.phpt
+++ b/tests/oo_ext_zip.phpt
@@ -2,7 +2,6 @@
 Extending Zip class and array property
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_externalattributes.phpt
+++ b/tests/oo_externalattributes.phpt
@@ -2,7 +2,6 @@
 ZipArchive::*ExternalAttributes*() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if (!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_extract.phpt
+++ b/tests/oo_extract.phpt
@@ -2,7 +2,6 @@
 extractTo
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_getcomment.phpt
+++ b/tests/oo_getcomment.phpt
@@ -2,7 +2,6 @@
 getComment
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_getnameindex.phpt
+++ b/tests/oo_getnameindex.phpt
@@ -2,7 +2,6 @@
 getNameIndex
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_namelocate.phpt
+++ b/tests/oo_namelocate.phpt
@@ -2,7 +2,6 @@
 Locate entries by name
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_open.phpt
+++ b/tests/oo_open.phpt
@@ -2,7 +2,6 @@
 zip::open() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_properties.phpt
+++ b/tests/oo_properties.phpt
@@ -2,7 +2,6 @@
 ziparchive::properties isset()/empty() checks
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_rename.phpt
+++ b/tests/oo_rename.phpt
@@ -2,7 +2,6 @@
 Rename entries
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_setcomment.phpt
+++ b/tests/oo_setcomment.phpt
@@ -2,7 +2,6 @@
 setComment
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_setcompression.phpt
+++ b/tests/oo_setcompression.phpt
@@ -2,7 +2,6 @@
 setCompressionName and setCompressionIndex methods
 --SKIPIF--
 <?php
-/* $Id$ */
 if (!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/oo_stream.phpt
+++ b/tests/oo_stream.phpt
@@ -2,7 +2,6 @@
 getStream
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/stream_meta_data.phpt
+++ b/tests/stream_meta_data.phpt
@@ -2,7 +2,6 @@
 stream_get_meta_data() on zip stream
 --SKIPIF--
 <?php
-/* $Id: oo_stream.phpt 260091 2008-05-21 09:27:41Z pajoye $ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/utils.inc
+++ b/tests/utils.inc
@@ -1,5 +1,5 @@
 <?php
-/* $Id$ */
+
 function dump_entries_name($z) {
 	for($i=0; $i<$z->numFiles; $i++) {
 	    $sb = $z->statIndex($i);

--- a/tests/zip_close.phpt
+++ b/tests/zip_close.phpt
@@ -2,7 +2,6 @@
 zip_close() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/zip_entry_close.phpt
+++ b/tests/zip_entry_close.phpt
@@ -2,7 +2,6 @@
 zip_entry_close() function: simple and double call
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/zip_entry_compressedsize.phpt
+++ b/tests/zip_entry_compressedsize.phpt
@@ -2,7 +2,6 @@
 zip_entry_compressedsize() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/zip_entry_compressionmethod.phpt
+++ b/tests/zip_entry_compressionmethod.phpt
@@ -2,7 +2,6 @@
 zip_entry_compressionmethod() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/zip_entry_filesize.phpt
+++ b/tests/zip_entry_filesize.phpt
@@ -2,7 +2,6 @@
 zip_entry_filesize() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/zip_entry_name.phpt
+++ b/tests/zip_entry_name.phpt
@@ -2,7 +2,6 @@
 zip_entry_name() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/zip_entry_open.phpt
+++ b/tests/zip_entry_open.phpt
@@ -2,7 +2,6 @@
 zip_entry_open() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/zip_entry_read.phpt
+++ b/tests/zip_entry_read.phpt
@@ -2,7 +2,6 @@
 zip_entry_read() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/zip_open.phpt
+++ b/tests/zip_open.phpt
@@ -2,7 +2,6 @@
 zip_open() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/tests/zip_read.phpt
+++ b/tests/zip_read.phpt
@@ -2,7 +2,6 @@
 zip_read() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--


### PR DESCRIPTION
The `$Id$` keywords were used in Subversion where they can be substituted with filename, last revision number change, last changed date, and last user who changed it.

In Git this functionality is different and can be done with Git attribute ident. These need to be defined manually for each file in the `.gitattributes` file and are afterwards replaced with 40-character
hexadecimal blob object name which is based only on the particular file contents.

This patch simplifies handling of `$Id$` keywords by removing them since they are not used anymore.