### PR TITLE
Fix Windows build for PHP 7.3 and 7.4

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -13,19 +13,22 @@ if (PHP_ZIP != "no") {
 			ERROR("zip not enabled; libraries not found");
 		}
 		
-		var dll = get_define('PHPDLL');
 		var old_conf_dir = configure_module_dirname;
 		
 		/* XXX tricky job here, override configure_module_dirname, define the basic extension,
 			then set it back*/
-		if (null != dll.match(/^php5/)) {
-			configure_module_dirname = configure_module_dirname + "\\php5";
-		} else if (null != dll.match(/^php7/)) {
-			configure_module_dirname = configure_module_dirname + "\\php7";
-		} else {
-			ERROR("Cannot match any known PHP version with '" + dll + "'");
-		}
-
+			if (PHP_VERSION == 5) {
+				configure_module_dirname = configure_module_dirname + "\\php5";
+			} else if (PHP_VERSION == 7 && PHP_MINOR_VERSION < 3) {
+				configure_module_dirname = configure_module_dirname + "\\php7";
+			} else if (PHP_VERSION == 7 && PHP_MINOR_VERSION == 3) {
+				configure_module_dirname = configure_module_dirname + "\\php73";
+			} else if (PHP_VERSION == 7 && PHP_MINOR_VERSION == 4) {
+				configure_module_dirname = configure_module_dirname + "\\php74";
+			} else {
+				ERROR("PHP " + PHP_VERSION + "." + PHP_MINOR_VERSION + " not supported");
+			}
+		
 		EXTENSION('zip', 'php_zip.c zip_stream.c');
 		configure_module_dirname = old_conf_dir;
 


### PR DESCRIPTION
PHP 7.3 and 7.4 are supposed to build from the php73 and php74
subfolders, respectively.  The detailed version information is not
available from the DLL, so we switch to checking `PHP_VERSION` and
`PHP_MINOR_VERSION`.