### PR TITLE
Remove unused PHP_ADD_MAKEFILE_FRAGMENT

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -151,7 +151,4 @@ if test "$PHP_ZIP" != "no"; then
     PHP_ADD_INCLUDE([$ext_srcdir/$subdir])
   fi
   PHP_SUBST(ZIP_SHARED_LIBADD)
-
-  dnl so we always include the known-good working hack.
-  PHP_ADD_MAKEFILE_FRAGMENT
 fi


### PR DESCRIPTION
There was once a Makefile fragment in this extension but has been removed a long time ago.