### PR TITLE
Add missing pcre dependency definition to zip extension

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -142,6 +142,7 @@ if test "$PHP_ZIP" != "no"; then
 
     AC_DEFINE(HAVE_ZIP,1,[ ])
     PHP_NEW_EXTENSION(zip, $PHP_ZIP_SOURCES, $ext_shared,, $LIBZIP_CFLAGS)
+    PHP_ADD_EXTENSION_DEP(zip, pcre)
   else
     AC_MSG_ERROR([libzip is no more bundled: install libzip version >= 0.11 (1.3.0 recommended for encryption and bzip2 support)])
   fi

--- a/config.w32
+++ b/config.w32
@@ -41,6 +41,7 @@ if (PHP_ZIP != "no") {
 			}
 		
 		EXTENSION('zip', 'php_zip.c zip_stream.c');
+		ADD_EXTENSION_DEP('zip', 'pcre');
 		configure_module_dirname = old_conf_dir;
 
 		AC_DEFINE('HAVE_ZIP', 1);

--- a/php81/php_zip.c
+++ b/php81/php_zip.c
@@ -1156,10 +1156,15 @@ static PHP_MSHUTDOWN_FUNCTION(zip);
 static PHP_MINFO_FUNCTION(zip);
 /* }}} */
 
+static const zend_module_dep zip_deps[] = {
+	ZEND_MOD_REQUIRED("pcre")
+	ZEND_MOD_END
+};
+
 /* {{{ zip_module_entry */
 zend_module_entry zip_module_entry = {
-	STANDARD_MODULE_HEADER,
-	"zip",
+	STANDARD_MODULE_HEADER_EX, NULL,
+	zip_deps,
 	ext_functions,
 	PHP_MINIT(zip),
 	PHP_MSHUTDOWN(zip),


### PR DESCRIPTION
The zip extension also requires the pcre extension.